### PR TITLE
Log timestamps in log_utils

### DIFF
--- a/core/utils/log_utils.cpp
+++ b/core/utils/log_utils.cpp
@@ -2,23 +2,35 @@
 #include "log_utils.h"
 
 #include <iostream>
-#include <time.h>
+#include <ctime>
 #include <sstream>
+#include <iomanip>
 
 namespace log_utils
 {
+	std::string timestamp()
+	{
+		std::stringstream resultStream;
+		std::time_t rawTime = std::time(nullptr);
+		std::tm *localTime = std::localtime(&rawTime);
+
+		resultStream << std::put_time(localTime, "%T");
+
+		return resultStream.str();
+	}
+
 	void info(const char* message)
 	{
-		std::cout << "[INFO] " << message << "\n";
+		std::cout << "[" << timestamp() << " INFO] " << message << "\n";
 	}
 
 	void success(const char* message)
 	{
-		std::cout << "\u001b[32m[SUCCESS] " << message << "\n\u001b[0m";
+		std::cout << "\u001b[32m" << "[" << timestamp() << " SUCCESS] " << message << "\n\u001b[0m";
 	}
 
 	void error(const char* message)
 	{
-		std::cerr << "\u001b[31m[ERROR] " << message << "\n\u001b[0m";
+		std::cerr << "\u001b[31m" << "[" << timestamp() << " ERROR] " << message << "\n\u001b[0m";
 	}
 }

--- a/core/utils/log_utils.h
+++ b/core/utils/log_utils.h
@@ -1,7 +1,9 @@
 #pragma once
+#include <string>
 
 namespace log_utils
 {
+	std::string timestamp();
 	void info(const char* message);
 	void success(const char* message);
 	void error(const char* message);


### PR DESCRIPTION
- Added a function "timestamp()" in log_utils namespace that returns the current timestamp in 24H format as an std::string
- timestamp() is used in the cout of the log functions
- Logged messages now look like this:
`[14:19:03 INFO] The example scene is now loaded.`

Fixes #16 